### PR TITLE
[Framework] Apply template method design pattern to BaseOrderingMethod

### DIFF
--- a/src/sofa/metis/MetisOrderingMethod.cpp
+++ b/src/sofa/metis/MetisOrderingMethod.cpp
@@ -98,7 +98,7 @@ void csrToAdjMETIS(int n, int * M_colptr, int * M_rowind, type::vector<int>& adj
     }
 }
 
-void MetisOrderingMethod::computePermutation(
+void MetisOrderingMethod::doComputePermutation(
     const SparseMatrixPattern& inPattern, int* outPermutation,
     int* outInversePermutation)
 {

--- a/src/sofa/metis/MetisOrderingMethod.h
+++ b/src/sofa/metis/MetisOrderingMethod.h
@@ -35,7 +35,7 @@ public:
 
     std::string methodName() const override;
 
-    void computePermutation(
+    void doComputePermutation(
         const SparseMatrixPattern& inPattern,
         int* outPermutation,
         int* outInversePermutation) override;


### PR DESCRIPTION
Update `MetisOrderingMethod` to use the new `BaseOrderingMethod::doComputePermutation`