### PR TITLE
Rollback to metis 5.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,12 +18,12 @@ set(SOURCE_FILES
 
 find_package(Sofa.Component.LinearSolver.Direct REQUIRED)
 
-find_package(metis 5.2.1 EXACT QUIET)
+find_package(metis 5.1.0 EXACT QUIET)
 if(NOT metis_FOUND AND SOFA_ALLOW_FETCH_DEPENDENCIES)
     message("Sofa.Metis: DEPENDENCY metis NOT FOUND. SOFA_ALLOW_FETCH_DEPENDENCIES is ON, fetching metis...")
     sofa_fetch_dependency(metis
             GIT_REPOSITORY https://github.com/sofa-framework/METIS
-            GIT_TAG v5.2.1-ModernInstall
+            GIT_TAG v5.1.0-ModernInstall
     )
 elseif (NOT metis_FOUND)
     message(FATAL_ERROR "Sofa.Metis: DEPENDENCY metis NOT FOUND. SOFA_ALLOW_FETCH_DEPENDENCIES is OFF and thus cannot be fetched. Install metis (version=5.2.1), or enable SOFA_ALLOW_FETCH_DEPENDENCIES to fix this issue.")


### PR DESCRIPTION
As the v5.2.1 is broken on Windows, we roll back to previous version